### PR TITLE
Add ATAS to DAP

### DIFF
--- a/3d_Assets/cfgMagazines.hpp
+++ b/3d_Assets/cfgMagazines.hpp
@@ -62,4 +62,9 @@ class CfgMagazines {
 	class rhs_mag_maaws_HE: CA_LauncherMagazine{mass = 34;};
 	class rhs_mag_maaws_HEAT: CA_LauncherMagazine{mass = 44;};
 	class rhs_mag_maaws_HEDP: CA_LauncherMagazine{mass = 36;};
+	class rhs_mag_ATAS_2;
+	class 3d_mag_ATAS_2: rhs_mag_ATAS_2 {
+	hardpoints[] = {"VTX_ST_L","VTX_ST_R","VTX_ST_OUTBOARD"};
+	pylonWeapon = "3d_weap_ATAS_launcher";
+};
 };

--- a/3d_Assets/cfgWeapons.hpp
+++ b/3d_Assets/cfgWeapons.hpp
@@ -497,4 +497,8 @@ class CfgWeapons
     class milgp_h_opscore_06_goggles_RGR {
          ace_hearing_protection = 0.80;  // Protection against deafening (0 to 1, higher means more protection)
 	};
+	class rhs_weap_ATAS_launcher;
+	class 3d_weap_ATAS_launcher: rhs_weap_ATAS_launcher {
+		magazines[] = {"3d_mag_ATAS_2"};
+	};
 };


### PR DESCRIPTION
Created a duplicate RHS_ATAS in Cfg Magazines and CfgWeapons in order to give it the DAPs hardpoint attachment slots. Couldn't figure out how to just add them onto the existing rhs ATAS config so thus the copied duplicate.